### PR TITLE
process_see_reference: look for name.s before functions

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -1176,6 +1176,10 @@ function Module:process_see_reference (s,modules,istype)
       end
       mod_ref = modules.by_name[self.package..'.'..s]
       if ismod(mod_ref) then return reference(s, mod_ref,nil) end
+
+      fun_ref = self.items.by_name[self.name..'.'..s]
+      if fun_ref then return reference(self.name..'.'..s,self,fun_ref) end
+
       fun_ref = self:get_fun_ref(s)
       if fun_ref then return reference(s,self,fun_ref)
       else


### PR DESCRIPTION
The `@see` reference for an item like the following might point to
itself, although this is in `@module tag` and there is
`tag.master_width_factor` also.

```
--- The default master width factor
--
-- @beautiful beautiful.master_width_factor
-- @param number (default: 0.5)
-- @see master_width_factor
-- @see gap
```

https://github.com/awesomeWM/awesome/blob/548b15e883836a2f784a4b163b097c3f523a68e0/lib/awful/tag.lua#L564-L569

This patch makes it look for the absolute reference using the module
name first.