### PR TITLE
Fix syntax errors in builtin.lpeg

### DIFF
--- a/ldoc/builtin/lpeg.lua
+++ b/ldoc/builtin/lpeg.lua
@@ -64,7 +64,7 @@ function lpeg.P(value) end
 -- characters with code between the codes of x and y (both inclusive).
 -- As an example, the pattern `lpeg.R("09")` matches any digit, and `lpeg.R("az",
 -- "AZ")` matches any ASCII letter.
-function lpeg.R({range}) end
+function lpeg.R(range) end
 
 ---
 -- Returns a pattern that matches any single character that appears in the given
@@ -197,7 +197,7 @@ function lpeg.Ct(patt) end
 ---
 -- Creates a match-time capture. Unlike all other captures, this one is
 -- evaluated immediately when a match occurs. It forces the immediate evaluation
--- of all its nested captures and then calls function.
+-- of all its nested captures and then calls func.
 -- The given function gets as arguments the entire subject, the current position
 -- (after the match of patt), plus any capture values produced by patt.
 -- The first value returned by function defines how the match happens. If the
@@ -209,6 +209,6 @@ function lpeg.Ct(patt) end
 -- match fails.
 -- Any extra values returned by the function become the values produced by the
 -- capture.
-function lpeg.Cmt(patt, function) end
+function lpeg.Cmt(patt, func) end
 
 return lpeg


### PR DESCRIPTION
```
template failed for my_module:
...share/lua/5.2/luarocks/loader.lua:147: error loading module 'ldoc.builtin.lpeg' from file '.../share/lua/5.2/ldoc/builtin/lpeg.lua':
    ...share/lua/5.2/ldoc/builtin/lpeg.lua:67: <name> or '...' expected near '{'
stack traceback:
    [C]: in function 'a_loader'
    ...share/lua/5.2/luarocks/loader.lua:147: in function <...share/lua/5.2/luarocks/loader.lua:144>
    (...tail calls...)
    [C]: in function 'require'
```

```
template failed for my_module:
...share/lua/5.2/luarocks/loader.lua:147: error loading module 'ldoc.builtin.lpeg' from file '...share/lua/5.2/ldoc/builtin/lpeg.lua':
    ...share/lua/5.2/ldoc/builtin/lpeg.lua:212: <name> or '...' expected near 'function'
stack traceback:
    [C]: in function 'a_loader'
    ...share/lua/5.2/luarocks/loader.lua:147: in function <...share/lua/5.2/luarocks/loader.lua:144>
    (...tail calls...)
    [C]: in function 'require'
```