### PR TITLE
Honor the TMPDIR environment variable

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -775,7 +775,7 @@ local builtin_style, builtin_template = match_bang(args.style),match_bang(args.t
 if builtin_style or builtin_template then
    -- '!' here means 'use built-in templates'
    local user = path.expanduser('~'):gsub('[/\\: ]','_')
-   local tmpdir = path.join(path.is_windows and os.getenv('TMP') or '/tmp','ldoc'..user)
+   local tmpdir = path.join(path.is_windows and os.getenv('TMP') or (os.getenv('TMPDIR') or '/tmp'),'ldoc'..user)
    if not path.isdir(tmpdir) then
       lfs.mkdir(tmpdir)
    end


### PR DESCRIPTION
When creating a temporary directory, use $TMPDIR as base directory if set, otherwise fall back to "/tmp".