### PR TITLE
Usage Cleanup & Add Command Line Option for Displaying Version Information

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -37,7 +37,7 @@ app.require_here()
 
 --- @usage
 local usage = [[
-ldoc, a documentation generator for Lua, vs ]]..version..[[
+ldoc, a documentation generator for Lua, v]]..version..[[
 
   -d,--dir (default doc) output directory
   -o,--output  (default 'index') output name

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -39,36 +39,40 @@ app.require_here()
 local usage = [[
 ldoc, a documentation generator for Lua, v]]..version..[[
 
-  -d,--dir (default doc) output directory
-  -o,--output  (default 'index') output name
-  -v,--verbose          verbose
-  -a,--all              show local functions, etc, in docs
-  -q,--quiet            suppress output
-  -m,--module           module docs as text
-  -s,--style (default !) directory for style sheet (ldoc.css)
-  -l,--template (default !) directory for template (ldoc.ltp)
-  -p,--project (default ldoc) project name
-  -t,--title (default Reference) page title
-  -f,--format (default plain) formatting - can be markdown, discount or plain
-  -b,--package  (default .) top-level package basename (needed for module(...))
-  -x,--ext (default html) output file extension
-  -c,--config (default config.ld) configuration name
-  -u,--unqualified     don't show package name in sidebar links
-  -i,--ignore ignore any 'no doc comment or no module' warnings
-  -X,--not_luadoc break LuaDoc compatibility. Descriptions may continue after tags.
-  -D,--define (default none) set a flag to be used in config.ld
-  -C,--colon use colon style
-  -N,--no_args_infer  don't infer arguments from source
-  -B,--boilerplate ignore first comment in source files
-  -M,--merge allow module merging
-  -S,--simple no return or params, no summary
-  -O,--one one-column output layout
-  --date (default system) use this date in generated doc
-  --dump                debug output dump
-  --filter (default none) filter output as Lua data (e.g pl.pretty.dump)
-  --tags (default none) show all references to given tags, comma-separated
-  --fatalwarnings non-zero exit status on any warning
-  --testing  reproducible build; no date or version on output
+  Invocation:
+    ldoc [options] <file>
+
+  Options:
+    -d,--dir		(default doc) output directory
+    -o,--output		(default 'index') output name
+    -v,--verbose	verbose
+    -a,--all		show local functions, etc, in docs
+    -q,--quiet		suppress output
+    -m,--module		module docs as text
+    -s,--style		(default !) directory for style sheet (ldoc.css)
+    -l,--template	(default !) directory for template (ldoc.ltp)
+    -p,--project	(default ldoc) project name
+    -t,--title		(default Reference) page title
+    -f,--format		(default plain) formatting - can be markdown, discount or plain
+    -b,--package	(default .) top-level package basename (needed for module(...))
+    -x,--ext		(default html) output file extension
+    -c,--config		(default config.ld) configuration name
+    -u,--unqualified	don't show package name in sidebar links
+    -i,--ignore		ignore any 'no doc comment or no module' warnings
+    -X,--not_luadoc	break LuaDoc compatibility. Descriptions may continue after tags.
+    -D,--define		(default none) set a flag to be used in config.ld
+    -C,--colon		use colon style
+    -N,--no_args_infer	don't infer arguments from source
+    -B,--boilerplate	ignore first comment in source files
+    -M,--merge		allow module merging
+    -S,--simple		no return or params, no summary
+    -O,--one		one-column output layout
+    --date		(default system) use this date in generated doc
+    --dump		debug output dump
+    --filter		(default none) filter output as Lua data (e.g pl.pretty.dump)
+    --tags		(default none) show all references to given tags, comma-separated
+    --fatalwarnings	non-zero exit status on any warning
+    --testing		reproducible build; no date or version on output
 
   <file> (string) source file or directory containing source
 

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -44,7 +44,6 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     ldoc --version
 
   Options:
-    -V,--version	show version information
     -d,--dir		(default doc) output directory
     -o,--output		(default 'index') output name
     -v,--verbose	verbose
@@ -69,6 +68,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     -M,--merge		allow module merging
     -S,--simple		no return or params, no summary
     -O,--one		one-column output layout
+    -V,--version	show version information
     --date		(default system) use this date in generated doc
     --dump		debug output dump
     --filter		(default none) filter output as Lua data (e.g pl.pretty.dump)
@@ -76,7 +76,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     --fatalwarnings	non-zero exit status on any warning
     --testing		reproducible build; no date or version on output
 
-  <file> (optional string) source file or directory containing source
+  <file> (string) source file or directory containing source
 
   `ldoc .` reads options from an `config.ld` file in same directory;
   `ldoc -c path/to/myconfig.ld <file>` reads options from `path/to/myconfig.ld`

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -41,8 +41,10 @@ ldoc, a documentation generator for Lua, v]]..version..[[
 
   Invocation:
     ldoc [options] <file>
+    ldoc --version
 
   Options:
+    -V,--version	show version information
     -d,--dir		(default doc) output directory
     -o,--output		(default 'index') output name
     -v,--verbose	verbose
@@ -74,7 +76,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     --fatalwarnings	non-zero exit status on any warning
     --testing		reproducible build; no date or version on output
 
-  <file> (string) source file or directory containing source
+  <file> (optional string) source file or directory containing source
 
   `ldoc .` reads options from an `config.ld` file in same directory;
   `ldoc -c path/to/myconfig.ld <file>` reads options from `path/to/myconfig.ld`
@@ -91,6 +93,11 @@ local parse = require 'ldoc.parse'
 local KindMap = tools.KindMap
 local Item,File,Module = doc.Item,doc.File,doc.Module
 local quit = utils.quit
+
+if args.version then
+   print('LDoc v' .. version)
+   os.exit(0)
+end
 
 
 local ModuleMap = class(KindMap)
@@ -349,6 +356,9 @@ else
       if err then quit("no "..quote(args.config).." found") end
    end
    -- with user-provided file
+   if args.file == nil then
+      lapp.error('missing required parameter: file')
+   end
    args.file = abspath(args.file)
 end
 


### PR DESCRIPTION
- Changes version string from "*vs X.X.X*" to "*vX.X.X*".
- Cleans up usage output so option descriptions are aligned.
- Creates version option (*-v* or *--version*).
  - Allows invoking *ldoc --version* without *file* parameter.