### PR TITLE
Fix error "attempt to index local 'mod' (a nil value)"

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -573,11 +573,13 @@ if ldoc.prettify_files then
    for F in file_list:iter() do
       files:append(F.filename)
       local mod = F.modules[1]
-      local ls = List()
-      for item in mod.items:iter() do
-         ls:append(item.lineno)
+      if mod then
+        local ls = List()
+        for item in mod.items:iter() do
+           ls:append(item.lineno)
+        end
+        linemap[F.filename] = ls
       end
-      linemap[F.filename] = ls
    end
 
    if type(ldoc.prettify_files) == 'table' then


### PR DESCRIPTION
This fixes an error in LDoc when it has the prettify option set and the user has a certain debugger source file in their path.

**Rationale**

The debugger is listed on [Lua-Users Wiki](http://lua-users.org/wiki/DebuggingLuaCode) ([GitHub Repo](https://github.com/slembcke/debugger.lua
)) as "Debugger.lua", considering it's prevalence online, submitting a fix is sensible.

**Conditions to reproduce**

* Configure `config.ld`
  * with the `prettify_files = true` or `prettify_files = "show"` option.
  * with the `file = "src"` directory where your source lives
* Download `debugger.lua` to your source directory
* Execute LDoc as usual

**Error Message**

```
format: using built-in markdown
lua: LDoc/ldoc.lua:577: attempt to index local 'mod' (a nil value)
stack traceback:
	LDoc/ldoc.lua:577: in main chunk
	[C]: in ?
```