### PR TITLE
Fix reference to undefined global variable

### DIFF
--- a/ldoc/markup.lua
+++ b/ldoc/markup.lua
@@ -316,7 +316,7 @@ local function markdown_processor(ldoc, formatter)
          return plain_processor(txt,item)
       end
       local is_file = utils.is_type(item,doc.File)
-      local is_module = not file and item and doc.project_level(item.type)
+      local is_module = not is_file and item and doc.project_level(item.type)
       if is_file or is_module then
         local deflang = 'lua'
         if ldoc.parse_extra and ldoc.parse_extra.C then


### PR DESCRIPTION
Maybe I'm missing something, but this appears to be a typo. I can't find any references to `file` that this may be trying to reference, so I assumed it must be intended to be `is_file`. If I'm wrong about this, I'd be happy to submit an alternate version that makes the global reference safe with `pcall`.

This is a problem because when I run with [Terra](http://terralang.org/) this throws an error (because Terra uses a strict mode by default that errors on undefined globals).