### PR TITLE
Fix Some "file" Issues

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -327,6 +327,13 @@ end
 
 local abspath = tools.abspath
 
+-- trim trailing forward slash
+if args.file then
+	while args.file:sub(#args.file, #args.file) == "/" do
+		args.file = args.file:sub(1, #args.file-1)
+	end
+end
+
 -- a special case: 'ldoc .' can get all its parameters from config.ld
 if args.file == '.' then
    local err

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -368,6 +368,13 @@ else
    args.file = abspath(args.file)
 end
 
+local source_dir = args.file
+
+-- override "file" from config
+if ldoc.file then
+	args.file = ldoc.file
+end
+
 if type(ldoc.custom_tags) == 'table' then -- custom tags
   for i, custom in ipairs(ldoc.custom_tags) do
     if type(custom) == 'string' then
@@ -378,7 +385,6 @@ if type(ldoc.custom_tags) == 'table' then -- custom tags
   end
 end -- custom tags
 
-local source_dir = args.file
 if type(source_dir) == 'table' then
    source_dir = source_dir[1]
 end

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -99,6 +99,13 @@ if args.version then
    os.exit(0)
 end
 
+local isdir_old = path.isdir
+path.isdir = function(p)
+	p = tools.trim_path_slashes(p)
+
+	return isdir_old(p)
+end
+
 
 local ModuleMap = class(KindMap)
 doc.ModuleMap = ModuleMap

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -329,9 +329,7 @@ local abspath = tools.abspath
 
 -- trim trailing forward slash
 if args.file then
-	while args.file:sub(#args.file, #args.file) == "/" do
-		args.file = args.file:sub(1, #args.file-1)
-	end
+	args.file = tools.trim_path_slashes(args.file)
 end
 
 -- a special case: 'ldoc .' can get all its parameters from config.ld

--- a/ldoc/tools.lua
+++ b/ldoc/tools.lua
@@ -537,6 +537,14 @@ function M.files_from_list (list, mask)
    return excl
 end
 
+function M.trim_path_slashes (st)
+	while st:sub(#st, #st) == "/" do
+		st = st:sub(1, #st-1)
+	end
+
+	return st
+end
+
 
 
 return tools


### PR DESCRIPTION
Does the following:
- trims trailing forward slashes from "file" parameter
  - allows setting parameter as "./"
- always overrides `args.file` with `ldoc.file` if not `nil`
  - fixes issue where `ldoc.file` is ignored if `args.file` is a directory other than "."

Closes: https://github.com/lunarmodules/LDoc/issues/279
Closes: https://github.com/lunarmodules/LDoc/issues/351