### PR TITLE
Add "import" Function and "UNSAFE_NO_SANDBOX" Flag for Accessing Built-in Lua Objects & Functions

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1255,7 +1255,7 @@ The string this function returns will be what's actually gets written out.
 
 _Available functions are:_
 
-  - `import(obj)` exposes Lua object `obj` to config.ld
+  - `import(obj)` exposes Lua object `obj` to config.ld (enabled with `--UNSAFE_NO_SANDBOX`)
   - `alias(a,tag)` provide an alias `a` for the tag `tag`, for instance `p` as short for
 `param`
   - `add_language_extension(ext,lang)` here `lang` may be either 'c' or 'lua', and `ext` is

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1255,6 +1255,7 @@ The string this function returns will be what's actually gets written out.
 
 _Available functions are:_
 
+  - `import(obj)` exposes Lua object `obj` to config.ld
   - `alias(a,tag)` provide an alias `a` for the tag `tag`, for instance `p` as short for
 `param`
   - `add_language_extension(ext,lang)` here `lang` may be either 'c' or 'lua', and `ext` is
@@ -1267,6 +1268,19 @@ that means `@tparam Object`.
   - `custom_see_handler(pattern,handler)`. If a reference matches `pattern`, then the
 extracted values will be passed to `handler`. It is expected to return link text
 and a suitable URI. (This match will happen before default processing.)
+
+## Importing Lua Objects
+
+The `import` function is available to gain access to built-in Lua functions & objects.
+
+```
+local print = import("print")
+local string = import("string")
+
+for _, s in ipairs({string.split("Hello world!")}) do
+	print(s)
+end
+```
 
 ## Annotations and Searching for Tags
 

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1255,7 +1255,7 @@ The string this function returns will be what's actually gets written out.
 
 _Available functions are:_
 
-  - `import(obj)` exposes Lua object `obj` to config.ld (enabled with `--UNSAFE_NO_SANDBOX`)
+  - `import(obj)` exposes Lua object `obj` to config.ld (enabled with `--unsafe_no_sandbox`)
   - `alias(a,tag)` provide an alias `a` for the tag `tag`, for instance `p` as short for
 `param`
   - `add_language_extension(ext,lang)` here `lang` may be either 'c' or 'lua', and `ext` is

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -76,6 +76,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     --testing		reproducible build; no date or version on output
     --icon		(default none) an image that will be displayed under the project name on all pages
     --multimodule	allow using @module, @script, @file, etc. multiple times in a file
+    --UNSAFE_NO_SANDBOX	disables sandbox and allows using `import` command in config.ld
 
   <file> (string) source file or directory containing source
 
@@ -248,10 +249,6 @@ function ldoc.custom_see_handler(pat, handler)
    doc.add_custom_see_handler(pat, handler)
 end
 
-function ldoc.import(t)
-	return (_G[t])
-end
-
 local ldoc_contents = {
    'alias','add_language_extension','custom_tags','new_type','add_section', 'tparam_alias',
    'file','project','title','package', 'icon','format','output','dir','ext', 'topics',
@@ -266,6 +263,16 @@ local ldoc_contents = {
    'custom_css','version',
    'no_args_infer', 'multimodule', 'import'
 }
+
+if args.UNSAFE_NO_SANDBOX then
+   function ldoc.import(t)
+      return (_G[t])
+   end
+
+   table.insert(ldoc_contents, 'import')
+end
+
+
 ldoc_contents = tablex.makeset(ldoc_contents)
 
 local function loadstr (ldoc,txt)

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -265,8 +265,21 @@ local ldoc_contents = {
 }
 
 if args.UNSAFE_NO_SANDBOX then
-   function ldoc.import(t)
-      return _G[t]
+   local select_locals = {
+      ["args"] = args,
+   }
+
+   function ldoc.import(t, env)
+      local retval = select_locals[t]
+      if not retval then
+         retval = _G[t]
+      end
+
+      if env then
+         env[t] = retval
+      end
+
+      return retval
    end
 
    table.insert(ldoc_contents, 'import')

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -248,6 +248,10 @@ function ldoc.custom_see_handler(pat, handler)
    doc.add_custom_see_handler(pat, handler)
 end
 
+function ldoc.import(t)
+	return (_G[t])
+end
+
 local ldoc_contents = {
    'alias','add_language_extension','custom_tags','new_type','add_section', 'tparam_alias',
    'file','project','title','package', 'icon','format','output','dir','ext', 'topics',
@@ -260,7 +264,7 @@ local ldoc_contents = {
    'dont_escape_underscore','global_lookup','prettify_files','convert_opt', 'user_keywords',
    'postprocess_html',
    'custom_css','version',
-   'no_args_infer', 'multimodule'
+   'no_args_infer', 'multimodule', 'import'
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -266,7 +266,7 @@ local ldoc_contents = {
 
 if args.UNSAFE_NO_SANDBOX then
    function ldoc.import(t)
-      return (_G[t])
+      return _G[t]
    end
 
    table.insert(ldoc_contents, 'import')

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -76,7 +76,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     --testing		reproducible build; no date or version on output
     --icon		(default none) an image that will be displayed under the project name on all pages
     --multimodule	allow using @module, @script, @file, etc. multiple times in a file
-    --UNSAFE_NO_SANDBOX	disables sandbox and allows using `import` command in config.ld
+    --unsafe_no_sandbox	disables sandbox and allows using `import` command in config.ld
 
   <file> (string) source file or directory containing source
 
@@ -264,7 +264,7 @@ local ldoc_contents = {
    'no_args_infer', 'multimodule', 'import'
 }
 
-if args.UNSAFE_NO_SANDBOX then
+if args.unsafe_no_sandbox then
    local select_locals = {
       ["args"] = args,
    }


### PR DESCRIPTION
Hoping this is a more acceptable solution than #308.

This adds an `import` function which is enabled with the `UNSAFE_NO_SANDBOX` command line flag & is used to access built-in Lua objects & functions within the `config.ld` file.

*Example config.ld:*
```lua
local print = import("print")
local string = import("string")

for _, s in ipairs({string.split("Hello world!")}) do
	print(s)
end

project = "foo"
title = "Bar"
file = {"init.lua"}
```

*Example execution:*
```
ldoc --UNSAFE_NO_SANDBOX .
```