### PR TITLE
Add Opton to Link to Favicon Image

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1252,6 +1252,7 @@ you want to display your own functions in a special way. Each keyword may be sty
   - `postprocess_html` function that allows a last-minute modification to the produced HTML page.
 The arguments are the raw HTML that's intended to be written out (a string), and the module object.
 The string this function returns will be what's actually gets written out.
+  - `favicon` A link to an image that browser's will display as each page's icon.
 
 _Available functions are:_
 

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -250,7 +250,7 @@ end
 
 local ldoc_contents = {
    'alias','add_language_extension','custom_tags','new_type','add_section', 'tparam_alias',
-   'file','project','title','package', 'icon','format','output','dir','ext', 'topics',
+   'file','project','title','package','icon','favicon','format','output','dir','ext', 'topics',
    'one','style','template','description','examples', 'pretty', 'charset', 'plain',
    'readme','all','manual_url', 'ignore', 'colon', 'sort', 'module_file','vars',
    'boilerplate','merge', 'wrap', 'not_luadoc', 'template_escape','merge_error_groups',

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -9,6 +9,9 @@ return [==[
 # if ldoc.custom_css then -- add custom CSS file if configured.
     <link rel="stylesheet" href="$(ldoc.custom_css)" type="text/css" />
 # end
+# if ldoc.favicon then
+    <link rel="icon" href="$(ldoc.favicon)" type="image/png" />
+# end
 </head>
 <body>
 


### PR DESCRIPTION
Adds option `favicon` that can be added to config to link to an image that browsers will display as each page's icon.

Example usage:
```lua
project = "minetest_mod"
title = "A Minetest Mod"
format = "markdown"
not_luadoc = true
boilerplate = false
wrap = false
style = true
favicon = "https://www.minetest.net/media/icon.svg"
```