### PR TITLE
Add test using type in @module and @submodule

### DIFF
--- a/tests/type/SimpleModule.lua
+++ b/tests/type/SimpleModule.lua
@@ -1,0 +1,23 @@
+-----------
+-- Simple module.
+-- This contains two types `Type1InModule` and `Type2InModule`,
+-- that are both listed as classes in the generated docs.
+-- @module CombinedModule
+
+--- Type1InModule description.
+-- @type Type1InModule
+Type1InModule = {}
+
+--- Type1InModule:A description.
+function Type1InModule:A()
+
+end
+
+--- Type2InModule description.
+-- @type Type2InModule
+Type2InModule = {}
+
+--- Type2InModule:A description.
+function Type2InModule:B()
+
+end

--- a/tests/type/Submodule_extra.lua
+++ b/tests/type/Submodule_extra.lua
@@ -1,0 +1,12 @@
+-----------
+-- Simple module distributed across two files.
+-- @submodule DistributedModule
+
+--- Type2InSubmodule description.
+-- @type Type2InSubmodule
+Type2InSubmodule = {}
+
+--- Type2InSubmodule:B description.
+function Type2InSubmodule:B()
+
+end

--- a/tests/type/Submodule_init.lua
+++ b/tests/type/Submodule_init.lua
@@ -1,0 +1,15 @@
+-----------
+-- Simple module distributed across two files.
+-- This contains two types `Type1InSubmodule` and `Type2InSubmodule`.
+-- While `Type1InSubmodule` is listed as a class in the generated docs,
+-- `Type2InSubmodule` is not. Instead only its functions are listed.
+-- @module DistributedModule
+
+--- Type1InSubmodule description.
+-- @type Type1InSubmodule
+Type1InSubmodule = {}
+
+--- Type1InSubmodule:A description.
+function Type1InSubmodule:A()
+
+end

--- a/tests/type/config.ld
+++ b/tests/type/config.ld
@@ -1,0 +1,1 @@
+file = {'SimpleModule.lua','Submodule_init.lua','Submodule_extra.lua'}


### PR DESCRIPTION
This PR adds a test using the `@type` tag in both a `@module` and `@submodule`. It shows that the generated docs are different for both cases:

`Type2InModule` is properly shown as a class, while `Type2InSubmodule` is not. Instead, only `Type2InSubmodule`'s functions are shown.