### PR TITLE
ldoc.lua: fix broken link, fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
   * With `export` tag, decide whether method is static or not
   * `classmod` classes now respect custom sections (#113)
   * Minor issues with prettification
-  * Command-line flags set explicitly take precendence over configuration file values.
+  * Command-line flags set explicitly take precedence over configuration file values.
   * Boilerplate Lua block comment ignored properly (#137)
   * Inline links with underscores sorted (#22)
   * Info section ordering is now consistent (#150)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ modules can be inferred from the code.
 LDoc is designed to give better diagnostics: if a `@see` reference cannot be found, then the
 line number of the reference is given.  LDoc knows about modules which do not use `module()`
 - this is important since this function has become deprecated in Lua 5.2. And you can avoid
-having to embed HTML in commments by using Markdown.
+having to embed HTML in comments by using Markdown.
 
 LDoc will also work with Lua C extension code, and provides some convenient shortcuts.
 

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -44,7 +44,7 @@ modules, functions, tables and types ("classes") of your API.
 ### Doc comments
 
 Only 'doc comments' are parsed; these can be started with at least 3 hyphens, or by a empty
-comment line with at least 3 hypens:
+comment line with at least 3 hyphens:
 
     --- summary.
     -- Description; this can extend over
@@ -259,7 +259,7 @@ can still start your modules the Lua 5.1 way:
 
 However, the 'module' function is deprecated in Lua 5.2 and it is increasingly
 common to see less 'magic' ways of creating modules, as seen in the description
-of the 'module' tag previously with the explicitely returned module table.
+of the 'module' tag previously with the explicitly returned module table.
 
 ### Repeating tags
 
@@ -931,7 +931,7 @@ with `kind_names` in `config.ld`. For instance, in Penlight I use `kind_names={t
 ## Customizing the Page
 
 A basic customization is to override the default UTF-8 encoding using `charset`. For instance,
-Brazillian software would find it useful to put `charset='ISO-8859-1'` in `config.ld`, or use
+Brazilian software would find it useful to put `charset='ISO-8859-1'` in `config.ld`, or use
 the **@charset** tag for individual files.
 
 Setting `no_return_or_parms` to `true` will suppress the display of 'param' and 'return'
@@ -1042,7 +1042,7 @@ Remember that the default is for references in backticks to be resolved; unlike 
 references, it is not an error if the reference cannot be found.
 
 The _sections_ of a document (the second-level headings) are also references. This
-particular section you are reading can be refered to as `@{\doc.md.Readme_files}` - the
+particular section you are reading can be referred to as `@{\doc.md.Readme_files}` - the
 rule is that any non-alphabetic character is replaced by an underscore.
 
 Any indented blocks are assumed to be Lua, unless their first line is `@plain`. New
@@ -1139,12 +1139,12 @@ This modifier can also be used with typed param aliases.
     -- you may document an indefinite number of extra arguments!
     -- @string name person's name
     -- @int age
-    -- @string[opt='gregorian'] calender optional calendar
+    -- @string[opt='gregorian'] calendar optional calendar
     -- @int[opt=0] offset optional offset
     -- @treturn string
     function one (name,age,...)
     end
-    ----> displayed as: one (name, age [, calender='gregorian' [, offset=0]])
+    ----> displayed as: one (name, age [, calendar='gregorian' [, offset=0]])
 
 (See @{four.lua})
 
@@ -1345,7 +1345,7 @@ and presentation makes this kind of new application possible with LDoc.
 
 From 1.4, LDoc has some limited support for generating Markdown output, although only
 for single files currently. Use `--ext md` for this.  'ldoc/html/ldoc_md_ltp.lua' defines
-the template for Markdown, but this can be overriden with `template` as above. It's another
+the template for Markdown, but this can be overridden with `template` as above. It's another
 example of minimal structure, and provides a better place to learn about these templates than the
 rather elaborate default HTML template.
 

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -7,7 +7,7 @@
 --
 -- C/C++ support for Lua extensions is provided.
 --
--- Available from LuaRocks as 'ldoc' and as a [Zip file](http://stevedonovan.github.com/files/ldoc-1.4.3.zip)
+-- Available from LuaRocks as 'ldoc' and as a [Zip file](https://github.com/lunarmodules/LDoc/archive/refs/tags/1.4.6.zip)
 --
 -- [Github Page](https://github.com/stevedonovan/ldoc)
 --

--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -557,7 +557,7 @@ function Item.check_tag(tags,tag, value, modifiers)
    return tag, value, modifiers
 end
 
--- any tag (except name and classs) may have associated modifiers,
+-- any tag (except name and class) may have associated modifiers,
 -- in the form @tag[m1,...] where  m1 is either name1=value1 or name1.
 -- At this stage, these are encoded
 -- in the tag value table and need to be extracted.

--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -11,7 +11,7 @@
 -- Like LuaDoc, LDoc puts similar kinds of documentation files in their own directories.
 -- So module docs go into 'modules/', scripts go into 'scripts/', and so forth. LDoc
 -- generalizes the idea of these project-level categories and in fact custom categories
--- can be created (refered to as 'kinds' in the code)
+-- can be created (referred to as 'kinds' in the code)
 
 local List = require 'pl.List'
 local utils = require 'pl.utils'
@@ -112,7 +112,7 @@ function html.generate_output(ldoc, args, project)
 
    -- this generates the internal module/function references
    function ldoc.href(see)
-      if see.href then -- explict reference, e.g. to Lua manual
+      if see.href then -- explicit reference, e.g. to Lua manual
          return see.href
       elseif doc.Module:class_of(see) then
          return ldoc.ref_to_module(see)

--- a/ldoc/lang.lua
+++ b/ldoc/lang.lua
@@ -135,7 +135,7 @@ local function parse_lua_table (tags,tok)
    end)
 end
 
---------------- function and variable inferrence -----------
+--------------- function and variable inference -----------
 -- After a doc comment, there may be a local followed by:
 -- [1] (l)function: function NAME
 -- [2] (l)function: NAME = function
@@ -202,7 +202,7 @@ end
 
 -- we only call the function returned by the item_follows above if there
 -- is not already a name and a type.
--- Otherwise, this is called. Currrently only tries to fill in the fields
+-- Otherwise, this is called. Currently only tries to fill in the fields
 -- of a table from a table definition as identified above
 function Lua:parse_extra (tags,tok,case)
    if tags.class == 'table' and not tags.field and case == 3 then

--- a/ldoc/markdown.lua
+++ b/ldoc/markdown.lua
@@ -10,7 +10,7 @@
 
 This is an implementation of the popular text markup language Markdown in pure Lua.
 Markdown can convert documents written in a simple and easy to read text format
-to well-formatted HTML. For a more thourough description of Markdown and the Markdown
+to well-formatted HTML. For a more thorough description of Markdown and the Markdown
 syntax, see <http://daringfireball.net/projects/markdown>.
 
 The original Markdown source is written in Perl and makes heavy use of advanced
@@ -128,7 +128,7 @@ setmetatable(M, MT)
 ----------------------------------------------------------------------
 
 -- Locks table t from changes, writes an error if someone attempts to change the table.
--- This is useful for detecting variables that have "accidently" been made global. Something
+-- This is useful for detecting variables that have "accidentally" been made global. Something
 -- I tend to do all too much.
 function M.lock(t)
 	local function lock_new_index(t, k, v)
@@ -854,7 +854,7 @@ local function code_spans(s)
 		local start, stop = s:find("`+", pos)
 		if not start then return s end
 		local count = stop - start + 1
-		-- Find a matching numbert of backticks
+		-- Find a matching number of backticks
 		local estart, estop = s:find(string.rep("`", count), stop+1)
 		local brstart = s:find("\n", stop+1)
 		if estart and (not brstart or estart < brstart) then

--- a/ldoc/parse.lua
+++ b/ldoc/parse.lua
@@ -163,7 +163,7 @@ end
 
 
 -- parses a Lua or C file, looking for ldoc comments. These are like LuaDoc comments;
--- they start with multiple '-'. (Block commments are allowed)
+-- they start with multiple '-'. (Block comments are allowed)
 -- If they don't define a name tag, then by default
 -- it is assumed that a function definition follows. If it is the first comment
 -- encountered, then ldoc looks for a call to module() to find the name of the

--- a/ldoc/tools.lua
+++ b/ldoc/tools.lua
@@ -319,7 +319,7 @@ local function type_of (tok) return tok and tok[1] or 'end' end
 local function value_of (tok) return tok[2] end
 
 -- This parses Lua formal argument lists. It will return a list of argument
--- names, which also has a comments field, which will contain any commments
+-- names, which also has a comments field, which will contain any comments
 -- following the arguments. ldoc will use these in addition to explicit
 -- param tags.
 

--- a/tests/md-test/mod2.lua
+++ b/tests/md-test/mod2.lua
@@ -1,6 +1,6 @@
 ---------------------
 -- Another test module.
--- This one uses _Markdown_ formating, and
+-- This one uses _Markdown_ formatting, and
 -- so can include goodies such as `code`
 -- and lists:
 --

--- a/tests/moonscript/List.moon
+++ b/tests/moonscript/List.moon
@@ -25,7 +25,7 @@ class List
     --- string representation
     __tostring: => '['..(concat @ls,',')..']'
 
-    --- return idx of first occurence of `item`
+    --- return idx of first occurrence of `item`
     find: (item) =>
         for i = 1,#@ls
             if @ls[i] == item then return i

--- a/tests/styles/four.lua
+++ b/tests/styles/four.lua
@@ -13,7 +13,7 @@
 -- you may document an indefinite number of extra arguments!
 -- @tparam ?string|Person name person's name
 -- @int age
--- @string[opt='gregorian'] calender optional calendar
+-- @string[opt='gregorian'] calendar optional calendar
 -- @int[opt=0] offset optional offset
 -- @treturn string
 -- @see file:write


### PR DESCRIPTION
This PR fixes and corrects the broken link to the `ldoc` .zip-file given mentioned in `ldoc.lua`. It also corrects several typos in the documentation an din source files.