### PR TITLE
Prettify function names

### DIFF
--- a/ldoc/html/_code_css.lua
+++ b/ldoc/html/_code_css.lua
@@ -9,6 +9,7 @@ pre .library { color: #0e7c6b; }
 pre .marker { color: #512b1e; background: #fedc56; font-weight: bold; }
 pre .string { color: #8080ff; }
 pre .number { color: #f8660d; }
+pre .function-name { color: #60447f; }
 pre .operator { color: #2239a8; font-weight: bold; }
 pre .preprocessor, pre .prepro { color: #a33243; }
 pre .global { color: #800080; }


### PR DESCRIPTION
I find it very helpful to colorize function names in our code examples. This also helps beginners understand that `x()`, `x {}` and `x ''` are all function calls. The implementation works for called functions and `[local] function name()` declarations, but not for `name = function()` declarations, which I think is fine.

In the process of doing this I found that LDoc wasn't running successfully under Lua 5.1, so I fixed that.

Tests run and pass. Example of prettified code using a css theme I'm working on:

<img width="483" alt="Screenshot 2022-10-24 at 13 56 08" src="https://user-images.githubusercontent.com/2369921/197530534-69f5d5a7-fb71-4c14-8575-872930e15f62.png">