### PR TITLE
Fix under Lua 5.1

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -261,8 +261,7 @@ local function loadstr (ldoc,txt)
    -- Penlight's Lua 5.2 compatibility has wobbled over the years...
    if not rawget(_G,'loadin') then -- Penlight 0.9.5
        -- Penlight 0.9.7; no more global load() override
-      local load = load or utils.load
-      chunk,err = load(txt,'config',nil,ldoc)
+      chunk,err = utils.load(txt,'config',nil,ldoc)
    else
       -- luacheck: push ignore 113
       chunk,err = loadin(ldoc,txt)


### PR DESCRIPTION
Lua 5.1 cannot accept a string as the first argument of `load`. Since the purpose of `pl.util.load` is to be compatible across Lua versions, this fixes LDoc under Lua 5.1, and I believe should also work for all other Lua versions.