### PR TITLE
Make @param tag multiline

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -23,7 +23,7 @@ local TAG_MULTI,TAG_ID,TAG_SINGLE,TAG_TYPE,TAG_FLAG,TAG_MULTI_LINE = 'M','id','S
 --  - 'N' tags which have no associated value, like 'local` (TAG_FLAG)
 --  - 'T' tags which represent a type, like 'function' (TAG_TYPE)
 local known_tags = {
-   param = 'M', see = 'M', comment = 'M', usage = 'ML', ['return'] = 'M', field = 'M', author='M',set='M';
+   param = 'ML', see = 'M', comment = 'M', usage = 'ML', ['return'] = 'M', field = 'M', author='M',set='M';
    class = 'id', name = 'id', pragma = 'id', alias = 'id',
    copyright = 'S', summary = 'S', description = 'S', release = 'S', license = 'S',
    fixme = 'S', todo = 'S', warning = 'S', raise = 'S', charset = 'S', within = 'S',


### PR DESCRIPTION
**Problem:** a last function parameter contains only first line of description, the rest lines moved to the function description when `not_luadoc = true`
**Example:**
```Lua
--- Connection REST API wrapper.
-- @classmod lua-repl.lib.rest.nmos.connection.api
-- <h3>Overview</h3>
-- The Connection API is exposed by NMOS Devices as a standard control interface for management of inter-device connections.<br />

--- Methods
-- @section methods

--- Allows staging and activation of a subset of multiple receiver parameters at the same time in a single request.<br />
--
-- @function api.bulk.receivers:post
-- @param payload1 (<span class="type">table/bulk_receiver_post_struct</span>[]) The actual subset of transport parameters used must be compatible with all receivers being addressed, which may be checked using the individual receiver's /constraints url.<br />
-- <b>payload1 second line</b>
-- @param payload2 (<span class="type">table/bulk_receiver_post_struct</span>[]) The actual subset of transport parameters used must be compatible with all receivers being addressed, which may be checked using the individual receiver's /constraints url.<br />
-- <b>payload2 second line</b>
```

**Fix:** make `@param` tag multiline