### PR TITLE
Do not remove `@see` references from internal data structure.

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -1227,10 +1227,6 @@ function Module:resolve_references(modules)
    for item in self.items:iter() do
       resolve_item_references(item); -- Resolve item-level see references.
    end
-   -- mark as found, so we don't waste time re-searching
-   for f in found:iter() do
-      f[1].tags.see:remove_value(f[2])
-   end
 end
 
 function Item:dump_tags (taglist)


### PR DESCRIPTION
Custom `--filter` functions will not see them.

There may be some utility in memoizing reference lookup, but I didn't notice any performance penalty when running ldoc on itself or my ~4000-line Lua project.