### PR TITLE
Support of LLS-style tags for @param and @return.

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -62,6 +62,7 @@ ldoc, a documentation generator for Lua, v]]..version..[[
     -X,--not_luadoc	break LuaDoc compatibility. Descriptions may continue after tags.
     -D,--define		(default none) set a flag to be used in config.ld
     -C,--colon		use colon style
+       --lls		use lua-language-server style
     -N,--no_args_infer	don't infer arguments from source
     -B,--boilerplate	ignore first comment in source files
     -M,--merge		allow module merging

--- a/ldoc/parse.lua
+++ b/ldoc/parse.lua
@@ -81,7 +81,7 @@ local function parse_lls_tags(text)
       local lls_param = '@param%s+([%w_]+)%s([%w_]+)%??%s*#?%s*(.*)'
       local param_name, param_type, param_desc = line:match(lls_param)
       local lls_ret = '@return%s+([%w_]+)%s*([%w]*)%s*#?%s*(.*)'
-      local ret_type, ret_name, ret_desc = line:match(lls_ret)
+      local ret_type, _, ret_desc = line:match(lls_ret)
       if param_type then
          -- LLS-style: param
          local modifiers = {['type'] = param_type}


### PR DESCRIPTION
LLS (lua-language-server) provides the following syntax for @param and @return:

@param name type # description
@param name type description
@param name type

@return type name # description
@return type name description
@return type # description
@return type