### PR TITLE
fix: Return original t in `find_module` if `search_for_token` fails

### DIFF
--- a/ldoc/lang.lua
+++ b/ldoc/lang.lua
@@ -111,10 +111,12 @@ end
 -- that we must infer the module name.
 function Lua:find_module(tok,t,v)
    local res
-   local st
-   res,st,v = self:search_for_token(tok,'iden','module',t,v)
+   -- st and sv are temporaries, which exist to ensure that `t` and `v`
+   -- are not clobbered if `res` is false-y.
+   local st, sv
+   res,st,sv = self:search_for_token(tok,'iden','module',t,v)
    if not res then return nil,t,v end
-   return self:parse_module_call(tok,st,v)
+   return self:parse_module_call(tok,st,sv)
 end
 
 local function parse_lua_parameters (tags,tok)

--- a/ldoc/lang.lua
+++ b/ldoc/lang.lua
@@ -111,9 +111,10 @@ end
 -- that we must infer the module name.
 function Lua:find_module(tok,t,v)
    local res
-   res,t,v = self:search_for_token(tok,'iden','module',t,v)
+   local st
+   res,st,v = self:search_for_token(tok,'iden','module',t,v)
    if not res then return nil,t,v end
-   return self:parse_module_call(tok,t,v)
+   return self:parse_module_call(tok,st,v)
 end
 
 local function parse_lua_parameters (tags,tok)


### PR DESCRIPTION
Fixes #258.


The if block starting at line 400 in ldoc/parse.lua is the problem.
It seems to look for a `module()` call, and then:
- if it finds one, uses that for the module name
- if it doesn't, infers the name from the filename etc.

This means that in all modern Lua code it will infer the name, obviously.
The issue is that in line 402, it calls `lang:find_module(tok, t, v)` (that is `Lua:find_module` from `lang.lua`), which will (for anything that doesn't use `module()`) return `nil, t, v` where `t, v` is from `self:search_for_token(tok, 'iden', 'module', t, v)`.

I know this is a bit to read, but here I believe the issue lies:

`Lang:search_for_token(...)` will return `t` as nil, here's why:

(from `search_for_token`)
```lua
   -- `t` may be nil here, which means it returns `false, nil, v`
   -- if `t` is nil
   return t ~= nil,t,v
```

And `find_module` says:
```lua
   res,t,v = self:search_for_token(tok,'iden','module',t,v)
   -- we know res may be `false` and `t` may be nil at the same time
   if not res then return nil,t,v end
```

We go back to `parse.lua`, line 402:

```lua
            module_found,t,v = lang:find_module(tok,t,v)
```

at this point `module_found` would be nil, and `t` would be nil also.

Now, a few lines down:

```lua
            if not t then
               F:warning('contains no items','warning',1)
               break;
            end -- run out of file!
```

So this is the issue - `t` may VERY well be nil.

Alternatively, we could:

- Remove the entire if statement that causes this warning, but Chestertons Fence speaks against this - I can't quite figure out exactly why this warning and the subsequent `break` need to be there, so I will not remove it.
- Remove the `break` only, and hope nothing relies on this - again, not sure that's the right move.

`t` arbitrarily being set to `nil` seems wrong here, so that's what I fixed, and it fixes the issue with the following reproducible sample:

```lua
--- my function
-- takes nothing and returns nothing
-- @return nothing
function DoNothing()
end

--
Thing = {
}
```

And also seems to work fine for code using `module()`.