### PR TITLE
fix: args.pretty always == nil, which will not enable lxsh

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -570,7 +570,7 @@ end
 -- (this also will initialize the code prettifier used)
 override ('format','plain')
 override 'pretty'
-ldoc.markup = markup.create(ldoc, args.format, args.pretty, ldoc.user_keywords)
+ldoc.markup = markup.create(ldoc, args.format, ldoc.pretty, ldoc.user_keywords)
 
 ------ 'Special' Project-level entities ---------------------------------------
 -- Examples and Topics do not contain code to be processed for doc comments.

--- a/ldoc/prettify.lua
+++ b/ldoc/prettify.lua
@@ -110,16 +110,15 @@ end
 
 local lxsh
 
-local lxsh_highlighers = {bib=true,c=true,lua=true,sh=true}
-
 function prettify.code (lang,fname,code,initial_lineno,pre)
    if not lxsh then
       return prettify.lua (lang,fname, code, initial_lineno, pre)
    else
-      if not lxsh_highlighers[lang] then
-         lang = 'lua'
+      local highlighter = lxsh.highlighters[lang]
+      if not highlighter then
+         return code
       end
-      code = lxsh.highlighters[lang](code, {
+      code = highlighter(code, {
          formatter = lxsh.formatters.html,
          external = true
       })


### PR DESCRIPTION
Allow developer to override lxsh_highlighers by lxsh.highlighers

Any third-party developer can provide a same API as lxsh for ldoc to syntax highlight.

An example: https://github.com/ustctug/texrocks/blob/main/packages/texcat/lua/lxsh.lua provide a lxsh API for ldoc. This is render result: https://texrocks.readthedocs.io/en/latest/topics/demo-tikz.md.html